### PR TITLE
SEEDSVT-318 redeliver edited submission to all REST Services

### DIFF
--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -113,15 +113,6 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
 
                 SSRFProtect.validate(self._hook.endpoint,
                                      options=ssrf_protect_options)
-                """
-                # For local Kobo instance to work:
-                # If we'll need to use an older version that doesn't allow to configure SSRF_ALLOWED_IP_ADDRESS,
-                # then we can turn SSRFProtect off through a flag configured in kobo-docker & kobo-install.
-                if os.getenv("SSRF_ON", "True") == "True":
-                    SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
-                else:
-                    logging.info("Skipping SSRFProtect with SSRF_ON=False")
-                """
 
                 response = requests.post(self._hook.endpoint, timeout=30, **request_kwargs)
                 response.raise_for_status()

--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -117,10 +117,10 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
                 # For local Kobo instance to work:
                 # If we'll need to use an older version that doesn't allow to configure SSRF_ALLOWED_IP_ADDRESS,
                 # then we can turn SSRFProtect off through a flag configured in kobo-docker & kobo-install.
-                if os.getenv("TASAI_VALIDATION_TOOL_LOCAL", "False") == "True":
+                if os.getenv("SSRF_ON", "True") == "True":
                     SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
                 else:
-                    logging.info("Skipping SSRFProtect with TASAI_VALIDATION_TOOL_LOCAL")
+                    logging.info("Skipping SSRFProtect with SSRF_ON=False")
                 """
 
                 response = requests.post(self._hook.endpoint, timeout=30, **request_kwargs)

--- a/kobo/apps/hook/models/service_definition_interface.py
+++ b/kobo/apps/hook/models/service_definition_interface.py
@@ -113,6 +113,15 @@ class ServiceDefinitionInterface(metaclass=ABCMeta):
 
                 SSRFProtect.validate(self._hook.endpoint,
                                      options=ssrf_protect_options)
+                """
+                # For local Kobo instance to work:
+                # If we'll need to use an older version that doesn't allow to configure SSRF_ALLOWED_IP_ADDRESS,
+                # then we can turn SSRFProtect off through a flag configured in kobo-docker & kobo-install.
+                if os.getenv("TASAI_VALIDATION_TOOL_LOCAL", "False") == "True":
+                    SSRFProtect.validate(self._hook.endpoint, options=ssrf_protect_options)
+                else:
+                    logging.info("Skipping SSRFProtect with TASAI_VALIDATION_TOOL_LOCAL")
+                """
 
                 response = requests.post(self._hook.endpoint, timeout=30, **request_kwargs)
                 response.raise_for_status()

--- a/kobo/apps/hook/utils.py
+++ b/kobo/apps/hook/utils.py
@@ -19,8 +19,8 @@ class HookUtils:
         # to make success equal True
         success = False
         for hook_id in hooks_ids:
-            if not HookLog.objects.filter(instance_id=instance_id, hook_id=hook_id).exists():
-                success = True
-                service_definition_task.delay(hook_id, instance_id)
+            # if not HookLog.objects.filter(instance_id=instance_id, hook_id=hook_id).exists():
+            success = True
+            service_definition_task.delay(hook_id, instance_id)
 
         return success


### PR DESCRIPTION
This PR is temporary for our internal reference. We need to decide against which tag/version to merge this change and in that case if we can use newer SSRF_ALLOWED_IP_ADDRESS setting or our custom SSRF_ON flag.